### PR TITLE
docs: add YouTube video thumbnail to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Microsoft Foundry DevTools
 
+[![Watch the Microsoft Foundry video on YouTube](https://img.youtube.com/vi/abc123XYZ/maxresdefault.jpg)](https://www.youtube.com/watch?v=abc123XYZ)
+
 [![Get started with Foundry](https://img.shields.io/badge/Foundry-Get_started-0078D4?style=flat-square)](https://learn.microsoft.com/en-us/azure/foundry/how-to/develop/install-cli-sdk?tabs=windows%2Cpython%2Cazd-ai)
 [![Install Foundry Toolkit for VS Code](https://img.shields.io/badge/VS_Code-Install_Toolkit-0098FF?style=flat-square)](https://marketplace.visualstudio.com/items?itemName=ms-windows-ai-studio.windows-ai-studio)
 [![Join the Foundry community on Discord](https://img.shields.io/badge/Discord-Join_the_community-5865F2?style=flat-square&logo=discord&logoColor=white)](https://aka.ms/azureaifoundry/discord)


### PR DESCRIPTION
## Summary

Add a clickable YouTube video thumbnail directly below the Microsoft Foundry DevTools title in README.md. The thumbnail opens the supplied YouTube video link.