### PR TITLE
docs: enable inline video playback in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microsoft Foundry DevTools
 
-[![Watch Your Entire Agentic AI Workflow Now Inside VS Code](./doc/foundry-toolkit-video-thumbnail.jpg)](./doc/foundry-toolkit-demo.mp4)
+https://github.com/user-attachments/assets/86eb98d6-d108-4c39-928c-0d3f15c9c92c
 
 [Watch on YouTube](https://www.youtube.com/watch?v=aQFSDGAk9DA) | [Download the video](./doc/foundry-toolkit-demo.mp4?raw=true)
 


### PR DESCRIPTION
## Summary
- Replace the linked thumbnail with a GitHub-hosted video attachment so the demo plays directly in the README, using the same approach as `github/app`.
- Add the matching YouTube thumbnail as a one-second opening frame, followed by the full original video. GitHub controls the player preview, so use of the opening frame as the preview is not guaranteed.
- Update the repository video under `doc/` to match the inline player and keep the YouTube and download links.

Follow-up to #765.

## Video

https://github.com/user-attachments/assets/66a5dd71-5bc6-4c6b-a4db-5676e364c74f