### PR TITLE
docs: add YouTube thumbnail as video opening frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microsoft Foundry DevTools
 
-https://github.com/user-attachments/assets/86eb98d6-d108-4c39-928c-0d3f15c9c92c
+https://github.com/user-attachments/assets/66a5dd71-5bc6-4c6b-a4db-5676e364c74f
 
 [Watch on YouTube](https://www.youtube.com/watch?v=aQFSDGAk9DA) | [Download the video](./doc/foundry-toolkit-demo.mp4?raw=true)
 


### PR DESCRIPTION
## Summary
- Add the matching YouTube thumbnail as a one-second opening frame, followed by the complete 1080p demo.
- Update both the repository video under `doc/` and the README's GitHub-hosted inline video.
- Keep the video below GitHub's 100 MiB file limit (91.9 MiB).

GitHub controls the player preview. The thumbnail is now the opening frame, but its use as the pre-play preview is not guaranteed.

Follow-up to #766, which merged while this update was in progress.

## Video

https://github.com/user-attachments/assets/66a5dd71-5bc6-4c6b-a4db-5676e364c74f